### PR TITLE
Refactor learner id usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "regmod>=0.0.8",
+        "regmod==0.0.8",
         "pplkit",
     ]
     test_requirements = [

--- a/src/modrover/learner.py
+++ b/src/modrover/learner.py
@@ -23,6 +23,7 @@ class Learner:
         model_type: str,
         y: str,
         param_specs: dict[str, dict],
+        all_covariates: list[str],
         offset: str = "offset",
         weights: str = "weights",
         model_eval_metric: Callable = get_rmse,
@@ -47,16 +48,11 @@ class Learner:
         self.offset = offset
         self.weights = weights
         self.model_eval_metric = model_eval_metric
+        self.all_covariates = all_covariates
 
         # Initialize null model
         self._model: Optional[RegmodModel] = None
         self.performance: Optional[float] = None
-
-        # extract all covariates
-        all_covariates = set()
-        for param_spec in param_specs.values():
-            all_covariates |= set(param_spec["variables"])
-        self.all_covariates = list(all_covariates)
 
         # convert str to Variable
         # TODO: this won't be necessary in regmod v1.0.0

--- a/src/modrover/learner.py
+++ b/src/modrover/learner.py
@@ -64,6 +64,7 @@ class Learner:
 
     @property
     def opt_coefs(self) -> Optional[np.ndarray]:
+        # TODO: If we have multiple parameters, what's the order of coefficients?
         if self._model:
             return self._model.opt_coefs
         return None

--- a/src/modrover/learner.py
+++ b/src/modrover/learner.py
@@ -20,7 +20,6 @@ class Learner:
 
     def __init__(
         self,
-        learner_id: LearnerID,
         model_type: str,
         y: str,
         param_specs: dict[str, dict],
@@ -31,7 +30,6 @@ class Learner:
         """
         Initialize a Rover submodel
 
-        :param learner_id: LearnerID, represents the covariate indices to fit on
         :param model_type: str, represents what type of model, e.g. gaussian, tobit, etc.
         :param col_obs: str, which column is the target column to predict out
         :param col_covs: list[str], all possible columns that rover can explore over
@@ -41,7 +39,6 @@ class Learner:
         :param model_eval_metric:
         :param optimizer_options:
         """
-        self.learner_id = learner_id
         self.model_type = model_type
 
         # TODO: Should these be parameters to fit, or instance attributes?
@@ -194,7 +191,7 @@ class Learner:
         model.attach_df(data)
         mat = model.mat[0]
         if np.linalg.matrix_rank(mat) < mat.shape[1]:
-            warn(f"Singular design matrix {self.learner_id=:}")
+            warn(f"Singular design matrix")
             return
 
         model.fit(**optimizer_options)
@@ -242,6 +239,3 @@ class Learner:
         model.data.detach_df()
 
         return performance
-
-    def __repr__(self):
-        return f"Learner({self.learner_id})"

--- a/src/modrover/strategies/base.py
+++ b/src/modrover/strategies/base.py
@@ -59,13 +59,6 @@ class RoverStrategy(ABC):
         cov_ids = list(map(int, cov_ids))
         cov_ids.sort()
 
-        if not all(map(lambda x: 0 <= x, cov_ids)):
-            raise ValueError("Cannot have negative covariate IDs")
-
-        if 0 not in cov_ids:
-            # Intercept always a fixed covariate, present in all models
-            cov_ids.insert(0, 0)
-
         return tuple(cov_ids)
 
     def _get_learner_id_children(self, learner_id: LearnerID) -> set[LearnerID]:

--- a/src/modrover/strategies/base.py
+++ b/src/modrover/strategies/base.py
@@ -59,18 +59,21 @@ class RoverStrategy(ABC):
         cov_ids = list(map(int, cov_ids))
         cov_ids.sort()
 
+        if not all(map(lambda x: 0 <= x, cov_ids)):
+            raise ValueError("Cannot have negative covariate IDs")
+
         return tuple(cov_ids)
 
     def _get_learner_id_children(self, learner_id: LearnerID) -> set[LearnerID]:
         """
         Create a new set of child covariate ID combinations based on the current one.
-        As an example, if we have 5 total covariates 1-5, and our current covariate ID
+        As an example, if we have 5 total explore covariates 0-4, and our current covariate ID
         is (0,1,2), this will return
-        [(0,1,2,3), (0,1,2,4), (0,1,2,5)]
+        [(0,1,2,3), (0,1,2,4)]
         :param num_covs: total number of covariates represented
         :return: A list of LearnerID classes wrapping the child covariate ID tuples
         """
-        all_covs_ids = set(range(1, self.num_covs + 1))
+        all_covs_ids = set(range(self.num_covs))
         remaining_cov_ids = all_covs_ids - set(learner_id)
         children = {
             self._as_learner_id((*learner_id, cov_id))
@@ -81,12 +84,12 @@ class RoverStrategy(ABC):
         """
         Create a parent LearnerID class with one less covariate than the current modelid.
         As an example, if our current covariate_id tuple is (0,1,2),
-        this function will return [(0,1), (0,2)]
+        this function will return [(0,1), (0,2), (1, 2)]
         :return:
         """
         parents = {
             self._as_learner_id((*learner_id[:i], *learner_id[(i + 1):]))
-            for i in range(1, len(learner_id))
+            for i in range(len(learner_id))
         }
         return parents
 

--- a/src/modrover/strategies/full_explore.py
+++ b/src/modrover/strategies/full_explore.py
@@ -8,7 +8,7 @@ class FullExplore(RoverStrategy):
 
     @property
     def base_learner_id(self) -> LearnerID:
-        return (0,)
+        return tuple()
 
     @property
     def first_layer(self) -> set[LearnerID]:
@@ -16,7 +16,7 @@ class FullExplore(RoverStrategy):
 
     @property
     def second_layer(self) -> set[LearnerID]:
-        all_cov_ids = range(1, self.num_covs + 1)
+        all_cov_ids = range(self.num_covs)
         second_layer = []
         for num_elements in range(1, self.num_covs + 1):
             second_layer.extend(map(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,7 @@ import pytest
 class MockLearner(Learner):
     """Mock learner that comes 'prefit' with coefficients."""
 
-    def __init__(self, learner_id: tuple, coefficients: np.ndarray, performance: float):
-        self.learner_id = learner_id
+    def __init__(self, coefficients: np.ndarray, performance: float):
         self.performance = performance
         self._model = lambda: None  # arbitrary mutable object that we can assign weights to
 
@@ -35,7 +34,7 @@ def mock_rover():
     ]
 
     learners = {
-        learner_id: MockLearner(learner_id, *params)
+        learner_id: MockLearner(*params)
         for learner_id, *params in learner_parameters
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,19 +18,20 @@ class MockLearner(Learner):
 class MockRover(Rover):
     """Mock Rover that comes 'prefit' with some mock data."""
 
-    def __init__(self, learners: dict, col_fixed: dict, col_explore: dict):
+    def __init__(self, learners: dict, col_fixed: dict, col_explore: list, explore_param: str):
         self.learners = learners
         self.col_fixed = col_fixed
         self.col_explore = col_explore
+        self.explore_param = explore_param
 
 
 @pytest.fixture
 def mock_rover():
 
     learner_parameters = [
-        ((0, 1, 3), np.array([.2, .4, .6]), 1.2),
-        ((0, 2, 3), np.array([0., .1, .5]), 1.),
-        ((0, 3), np.array([1., -.2]), -.3),
+        ((1, 3), np.array([.2, .4, .6]), 1.2),
+        ((2, 3), np.array([0., .1, .5]), 1.),
+        ((3, ), np.array([1., -.2]), -.3),
     ]
 
     learners = {
@@ -41,6 +42,7 @@ def mock_rover():
     rover = MockRover(
         learners=learners,
         col_fixed={'mu': [0]},
-        col_explore={'mu': [1, 2, 3, 4]}
+        col_explore=[1, 2, 3, 4],
+        explore_param='mu'
     )
     return rover

--- a/tests/integration/test_ensembles.py
+++ b/tests/integration/test_ensembles.py
@@ -82,10 +82,11 @@ def test_generate_coefficient_means(mock_rover):
 def test_superlearner_creation(mock_rover):
     """Test that we can create a super learner object from rover after fitting."""
     mock_rover.get_learner = lambda learner_id, use_cache: \
-        Learner(learner_id=tuple(range(5)),
-                model_type='gaussian',
-                y='y',
-                param_specs={'mu': {'variables': list(range(5))}})
+        Learner(
+            model_type='gaussian',
+            y='y',
+            param_specs={'mu': {'variables': list(range(5))}}
+        )
 
     super_learner = mock_rover._create_super_learner(
         max_num_models=10,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -21,7 +21,8 @@ def test_rover():
         model_type='gaussian',
         y='y',
         col_fixed={'mu': ['intercept']},
-        col_explore={'mu': ['var_a', 'var_b']},
+        col_explore=['var_a', 'var_b'],
+        explore_param='mu',
         holdout_cols=['holdout']
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,5 +27,5 @@ def test_rover():
     )
 
     rover.fit(dataset=dataframe, strategy='full', ratio_cutoff=.0)
-    assert set(rover.learners.keys()) == {(0,), (0, 1), (0, 2), (0, 1, 2)}
+    assert set(rover.learners.keys()) == {tuple(), (0,), (1,), (0, 1)}
     assert isinstance(rover.super_learner, Learner)

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -37,9 +37,8 @@ def model_specs():
 
 
 def test_model_init(model_specs):
-    # Arbitrary: select first 2 covariates out of 5
-    learner_id = (0, 1, 2, 3)
-    model = Learner(learner_id=learner_id, **model_specs)
+    # select first 3 covariates out of 5
+    model = Learner(**model_specs)
     # Check that model is "new"
     assert not model.has_been_fit
     assert model.opt_coefs is None
@@ -53,8 +52,7 @@ def test_model_init(model_specs):
 
 def test_model_fit(dataset, model_specs):
 
-    learner_id = (0, 1, 2, 3, 4, 5, 6)
-    model = Learner(learner_id=learner_id, **model_specs)
+    model = Learner(**model_specs)
 
     # Fit the model, don't check for correctness
     model.fit(dataset, holdout_cols=['holdout_1', 'holdout_2'])
@@ -68,10 +66,7 @@ def test_two_param_model_fit(dataset):
 
     # Sample two param model: a,b,c are mapped to mu, d,e to sigma
 
-    learner_id = (0, 1, 2)
-
     model = Learner(
-        learner_id=learner_id,
         model_type='tobit',
         y='y',
         param_specs={
@@ -97,8 +92,7 @@ def test_two_param_model_fit(dataset):
 
 def test_initialize_model_with_coefs(model_specs):
 
-    learner_id = (0, 1, 2, 3)
-    model = Learner(learner_id=learner_id, **model_specs)
+    model = Learner(**model_specs)
 
     # Set some known coefficients, random number
     # 3 covariates implies 3 coefficients

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -8,36 +8,39 @@ from modrover.learner import Learner, LearnerID
 @pytest.fixture
 def dataset():
     data = np.random.randn(25, 6)
-    columns = [
+    covariate_columns = [
         'var_a',
         'var_b',
         'var_c',
         'var_d',
         'var_e',
         'y']
-    dataframe = pd.DataFrame(data, columns=columns)
+    dataframe = pd.DataFrame(data, columns=covariate_columns)
     # Fill in intercept and holdout columns
     dataframe['intercept'] = 1
     dataframe['holdout_1'] = np.random.randint(0, 2, 25)
     dataframe['holdout_2'] = np.random.randint(0, 2, 25)
-    return dataframe
+    # Drop y covariate since it's the observed column
+    return covariate_columns[:-1], dataframe
 
 
 @pytest.fixture
-def model_specs():
+def model_specs(dataset):
+    all_covariates, _ = dataset
     specs = dict(
         model_type='gaussian',
         y='y',
         param_specs={
             'mu': {"variables": ['intercept', 'var_a', 'var_b', 'var_c']}
         },
+        all_covariates=all_covariates[:-2],
         offset='offset',
     )
     return specs
 
 
 def test_model_init(model_specs):
-    # select first 3 covariates out of 5
+    # In param_specs, we'll select the intercept term plus 3/5 covariates
     model = Learner(**model_specs)
     # Check that model is "new"
     assert not model.has_been_fit
@@ -55,17 +58,19 @@ def test_model_fit(dataset, model_specs):
     model = Learner(**model_specs)
 
     # Fit the model, don't check for correctness
-    model.fit(dataset, holdout_cols=['holdout_1', 'holdout_2'])
+    _, dataframe = dataset
+    model.fit(dataframe, holdout_cols=['holdout_1', 'holdout_2'])
     assert 0 <= model.performance <= 1
     assert model.opt_coefs is not None
     assert isinstance(model.opt_coefs, np.ndarray)
+    assert len(model.opt_coefs == 4)  # Intercept + 3 covariate terms
     assert isinstance(model.vcov, np.ndarray)
 
 
 def test_two_param_model_fit(dataset):
 
     # Sample two param model: a,b,c are mapped to mu, d,e to sigma
-
+    covariate_cols, dataframe = dataset
     model = Learner(
         model_type='tobit',
         y='y',
@@ -77,16 +82,21 @@ def test_two_param_model_fit(dataset):
                 "variables": ['intercept', 'var_d', 'var_e'],
             }
         },
+        all_covariates=covariate_cols,
     )
 
     # Should have 2 mu columns, 2 sigma columns, and the intercept
     regmod_model = model._initialize_model()
     assert set(regmod_model.data.col_covs) == {'var_a', 'var_b', 'var_c', 'var_d', 'var_e', 'intercept'}
 
-    model.fit(dataset, holdout_cols=['holdout_1', 'holdout_2'])
+    model.fit(dataframe, holdout_cols=['holdout_1', 'holdout_2'])
     assert 0 <= model.performance <= 1
     assert model.opt_coefs is not None
     assert isinstance(model.opt_coefs, np.ndarray)
+    # TODO: Confirm this test case
+    # intercept is counted as a column in both mu and sigma. Is that possible?
+    # Result: intercept x2 + 5 covariates = 7 coefficients
+    assert len(model.opt_coefs) == 7
     assert isinstance(model.vcov, np.ndarray)
 
 
@@ -95,11 +105,11 @@ def test_initialize_model_with_coefs(model_specs):
     model = Learner(**model_specs)
 
     # Set some known coefficients, random number
-    # 3 covariates implies 3 coefficients
+    # Intercept + 3 covariates implies 4 coefficients
     expected_coefs = np.array([-.5, -.3, .3, .2])
     model.opt_coefs = expected_coefs
     assert np.isclose(model.opt_coefs, expected_coefs).all()
 
     with pytest.raises(ValueError):
-        # Setting 4 coefficients on 3 variables should raise an error
+        # Setting 5 coefficients on 4 variables should raise an error
         model.opt_coefs = np.append(expected_coefs, .4)

--- a/tests/test_rover.py
+++ b/tests/test_rover.py
@@ -20,3 +20,28 @@ def test_get_learner():
     assert learner.all_covariates == ['intercept', 'cov1', 'cov2', 'cov3']
     variables = learner.param_specs['mu']['variables']
     assert [var.name for var in variables] == learner.all_covariates
+
+
+def test_empty_learner_id():
+
+    # Special test for the learner with no explore covariates, only fixed
+    rover = Rover(
+        model_type="gaussian",
+        y="obs",
+        col_fixed={"mu": ["intercept"]},
+        col_explore=["cov1", "cov2", "cov3"],
+        explore_param='mu'
+    )
+
+    assert rover.default_param_specs == {
+        'mu': {
+            'variables': [
+                'intercept'
+            ]
+        }
+    }
+
+    learner = rover.get_learner(tuple())
+    variables = learner.param_specs['mu']['variables']
+    assert len(variables) == 1
+    assert variables[0].name == 'intercept'

--- a/tests/test_rover.py
+++ b/tests/test_rover.py
@@ -7,9 +7,16 @@ def test_get_learner():
         model_type="gaussian",
         y="obs",
         col_fixed={"mu": ["intercept"]},
-        col_explore={"mu": ["cov1", "cov2", "cov3"]},
+        col_explore=["cov1", "cov2", "cov3"],
+        explore_param='mu'
     )
 
     learner = rover.get_learner((0, 1, 2))
 
     assert isinstance(learner, Learner)
+    assert len(learner.all_covariates) == 4
+    assert len(learner.param_specs['mu']['variables']) == 4
+    # Check that the order is preserved
+    assert learner.all_covariates == ['intercept', 'cov1', 'cov2', 'cov3']
+    variables = learner.param_specs['mu']['variables']
+    assert [var.name for var in variables] == learner.all_covariates


### PR DESCRIPTION
PR-ing this into the existing ensembling branch, so that the diff is slightly more obvious. 

Following the mental model of learner IDs specifically identifying combinations of explore columns that parametrize a model, update the rover get_learner, strategy, and ensemble methods to operate with the correct indices set. 

