### PR TITLE
Msca 220/update rover for two parameter

### DIFF
--- a/src/modrover/learner.py
+++ b/src/modrover/learner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from operator import attrgetter
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 from warnings import warn
 
 import numpy as np
@@ -10,8 +10,7 @@ from regmod.data import Data
 from regmod.models import Model as RegmodModel
 from regmod.variable import Variable
 
-from .globals import get_rmse, model_type_dict
-from .exceptions import InvalidConfigurationError
+from .globals import get_rmse
 
 LearnerID = tuple[int, ...]
 
@@ -20,7 +19,7 @@ class Learner:
 
     def __init__(
         self,
-        model_type: str,
+        model_type: type,
         y: str,
         param_specs: dict[str, dict],
         all_covariates: list[str],
@@ -76,15 +75,6 @@ class Learner:
         self._model.opt_coefs = opt_coefs
 
     @property
-    def model_class(self):
-        if self.model_type not in model_type_dict:
-            raise InvalidConfigurationError(
-                f"Model type {self.model_type} not known, "
-                f"please select from {list(model_type_dict.keys())}"
-            )
-        return model_type_dict[self.model_type]
-
-    @property
     def vcov(self) -> Optional[np.ndarray]:
         if self._model:
             return self._model.opt_vcov
@@ -126,8 +116,7 @@ class Learner:
 
         # Create regmod variables separately, by parameter
         # Initialize with fixed parameters
-        # TODO: Does intercept get counted across multiple parameters?
-        model = self.model_class(
+        model = self.model_type(
             data=data,
             param_specs=self.param_specs,
         )

--- a/src/modrover/strategies/backward_explore.py
+++ b/src/modrover/strategies/backward_explore.py
@@ -6,7 +6,7 @@ class BackwardExplore(RoverStrategy):
 
     @property
     def base_learner_id(self) -> LearnerID:
-        return tuple(range(self.num_covs + 1))
+        return tuple(range(self.num_covs))
 
     def get_next_layer(
         self,

--- a/src/modrover/strategies/forward_explore.py
+++ b/src/modrover/strategies/forward_explore.py
@@ -6,7 +6,7 @@ class ForwardExplore(RoverStrategy):
 
     @property
     def base_learner_id(self) -> LearnerID:
-        return (0,)
+        return tuple()
 
     def get_next_layer(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from modrover.rover import Rover
 from modrover.learner import Learner
+from regmod.models.gaussian import GaussianModel
 
 import numpy as np
 import pytest
@@ -18,11 +19,13 @@ class MockLearner(Learner):
 class MockRover(Rover):
     """Mock Rover that comes 'prefit' with some mock data."""
 
-    def __init__(self, learners: dict, col_fixed: dict, col_explore: list, explore_param: str):
+    def __init__(self, learners: dict, col_fixed: dict,
+                 col_explore: list, explore_param: str, model_type: str = 'gaussian'):
         self.learners = learners
         self.col_fixed = col_fixed
         self.col_explore = col_explore
         self.explore_param = explore_param
+        self.model_type = model_type
 
 
 @pytest.fixture

--- a/tests/integration/test_ensembles.py
+++ b/tests/integration/test_ensembles.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from modrover.globals import model_type_dict
 from modrover.learner import Learner
 from modrover.synthesizer import metrics_to_weights
 
@@ -71,7 +72,6 @@ def test_two_parameter_coefficient_mapping(mock_rover):
     assert np.allclose(row, [.1, .3, .2, 0, .4])
 
 
-
 def test_covariate_matrix_generation(mock_rover):
     # Check weight generation
     learner_ids, coeff_means = mock_rover._generate_coefficients_matrix()
@@ -130,7 +130,7 @@ def test_superlearner_creation(mock_rover):
     """Test that we can create a super learner object from rover after fitting."""
     mock_rover.get_learner = lambda learner_id, use_cache: \
         Learner(
-            model_type='gaussian',
+            model_type=model_type_dict['gaussian'],
             y='y',
             all_covariates=list(range(5)),
             param_specs={'mu': {'variables': list(range(5))}}

--- a/tests/integration/test_ensembles.py
+++ b/tests/integration/test_ensembles.py
@@ -47,6 +47,31 @@ def test_learner_coefficient_mapping(mock_rover):
     assert np.allclose(row, [.1, .3, 0, 0, .2])
 
 
+def test_two_parameter_coefficient_mapping(mock_rover):
+    """Test that covariate aggregation works for multiple parameter models."""
+
+    mock_rover.model_type = "tobit"
+    mock_rover.col_fixed = {
+        'mu': [0, 3],
+        'sigma': [4],
+    }
+    mock_rover.col_explore = [1, 2]
+    mock_rover.explore_param = "mu"
+
+    # Expected ordering out of a particular model:
+    # Say learner_id = (0,) - represents both parameters
+    # Expected covariate order is then [0, 3, 1, 4] - Tobit model defines mu -> sigma
+    # as the parameter order
+    # Rover appends the explore columns to the end of the mu fixed columns
+
+    learner_id, coefficients = (0, ), np.array([.1, .3, .2, .4])
+
+    row = mock_rover._learner_coefs_to_global_coefs(learner_id, coefficients)
+
+    assert np.allclose(row, [.1, .3, .2, 0, .4])
+
+
+
 def test_covariate_matrix_generation(mock_rover):
     # Check weight generation
     learner_ids, coeff_means = mock_rover._generate_coefficients_matrix()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -29,3 +29,35 @@ def test_rover():
     rover.fit(dataset=dataframe, strategy='full', ratio_cutoff=.0)
     assert set(rover.learners.keys()) == {tuple(), (0,), (1,), (0, 1)}
     assert isinstance(rover.super_learner, Learner)
+
+
+def test_two_parameter_rover():
+    data = np.random.randn(25, 5)
+    columns = [
+        'var_a',
+        'var_b',
+        'var_c',
+        'var_d',
+        'y']
+    dataframe = pd.DataFrame(data, columns=columns)
+    # Fill in intercept and holdout columns
+    dataframe['intercept'] = 1
+    dataframe['holdout'] = np.random.randint(0, 2, 25)
+
+    rover = Rover(
+        model_type='tobit',
+        y='y',
+        col_fixed={
+            'mu': ['intercept', 'var_a'],
+            'sigma': ['intercept', 'var_b']},
+        col_explore=['var_c', 'var_d'],
+        explore_param='mu',
+        holdout_cols=['holdout']
+    )
+
+    rover.fit(dataset=dataframe, strategy='backward', ratio_cutoff=.0)
+    assert set(rover.learners.keys()) == {tuple(), (0,), (1,), (0, 1)}
+    # Should have 6 coefficients:
+    #   mu - intercept, a, c, d
+    #   sigma - intercept, b
+    assert rover.super_learner.opt_coefs.shape == (6, )

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from modrover.globals import model_type_dict
 from modrover.learner import Learner, LearnerID
 
 
@@ -28,7 +29,7 @@ def dataset():
 def model_specs(dataset):
     all_covariates, _ = dataset
     specs = dict(
-        model_type='gaussian',
+        model_type=model_type_dict['gaussian'],
         y='y',
         param_specs={
             'mu': {"variables": ['intercept', 'var_a', 'var_b', 'var_c']}
@@ -72,7 +73,7 @@ def test_two_param_model_fit(dataset):
     # Sample two param model: a,b,c are mapped to mu, d,e to sigma
     covariate_cols, dataframe = dataset
     model = Learner(
-        model_type='tobit',
+        model_type=model_type_dict['tobit'],
         y='y',
         param_specs={
             'mu': {
@@ -93,9 +94,7 @@ def test_two_param_model_fit(dataset):
     assert 0 <= model.performance <= 1
     assert model.opt_coefs is not None
     assert isinstance(model.opt_coefs, np.ndarray)
-    # TODO: Confirm this test case
-    # intercept is counted as a column in both mu and sigma. Is that possible?
-    # Result: intercept x2 + 5 covariates = 7 coefficients
+    # Result: intercept + 5 covariates + intercept = 7 coefficients
     assert len(model.opt_coefs) == 7
     assert isinstance(model.vcov, np.ndarray)
 


### PR DESCRIPTION
The main push in this PR is to update the ensembling algorithm to allow for multiple coefficients in the two parameter model case. 

Key assumption is that coefficients in a regmod model is ordered by 
1. parameter type
2. order supplied to the variable key

Also, there's now a passing integration test for the two-parameter rover case