### PR TITLE
add intercept to summary

### DIFF
--- a/src/modrover/learner.py
+++ b/src/modrover/learner.py
@@ -154,7 +154,7 @@ class Learner:
         if self.status != ModelStatus.CV_FAILED:
             self.status = self._fit(data, **optimizer_options)
             # If holdout cols not provided, use in-sample evaluate for the full data model
-            if self.status == ModelStatus.SUCCESS and (not holdout):
+            if self.status == ModelStatus.SUCCESS and (not holdouts):
                 self.score = self.evaluate(data)
 
     def predict(

--- a/src/modrover/rover.py
+++ b/src/modrover/rover.py
@@ -557,25 +557,28 @@ class Rover:
             self.learner_info["status"] == ModelStatus.SUCCESS
         ]
         learner_scores = dict(zip(learner_info["learner_id"], learner_info["score"]))
+
+        all_covs = self.cov_fixed + self.cov_exploring
         # ensemble info
+        # TODO: Isn't this always all covariates? for the super learner?
         coef_index = [
-            variables.index(f"{self.main_param}_{cov}") for cov in self.cov_exploring
+            variables.index(f"{self.main_param}_{cov}") for cov in all_covs
         ]
         coef = self.super_learner.coef[coef_index]
         coef_sd = np.sqrt(np.diag(self.super_learner.vcov)[coef_index])
         # number of models the covariate is present
         pct_present = [
             (learner_info[f"{self.main_param}_{cov}"] != 0.0).sum() / len(learner_info)
-            for cov in self.cov_exploring
+            for cov in all_covs
         ]
         # score when only the selected covariate is present
-        single_score = [
+        single_score = [np.nan] * len(self.cov_fixed) + [
             learner_scores.get((i,), np.nan) for i in range(len(self.cov_exploring))
         ]
         # average score when selected covariate is present or not
         present_score = []
         not_present_score = []
-        for cov in self.cov_exploring:
+        for cov in all_covs:
             present_index = learner_info[f"{self.main_param}_{cov}"] != 0.0
             ps, nps = 0.0, 0.0
             if any(present_index):
@@ -587,7 +590,7 @@ class Rover:
 
         df = DataFrame(
             {
-                "cov": self.cov_exploring,
+                "cov": all_covs,
                 "coef": coef,
                 "coef_sd": coef_sd,
                 "pct_present": pct_present,


### PR DESCRIPTION
The demographics team wanted to see intercept terms in the summary from rover, which seem to be missing. 